### PR TITLE
Draw ui with state

### DIFF
--- a/R/block-ui.R
+++ b/R/block-ui.R
@@ -41,14 +41,16 @@ block_ui.block <- function(id, x, ...) {
   NULL
 }
 
+#' @param state Optional block state, which will be added to the environment
+#' where the block `expr` UI is created
 #' @rdname block_ui
 #' @export
-expr_ui <- function(id, x, ...) {
+expr_ui <- function(id, x, state = list(), ...) {
   UseMethod("expr_ui", x)
 }
 
 #' @export
-expr_ui.block <- function(id, x, ...) {
+expr_ui.block <- function(id, x, state = list(), ...) {
 
   if (...length()) {
     abort(
@@ -59,7 +61,23 @@ expr_ui.block <- function(id, x, ...) {
     )
   }
 
-  do.call(block_expr_ui(x), list(id = NS(id, "expr")))
+  if (!is.list(state) || length(unique(names(state))) != length(state)) {
+    abort(
+      paste(
+        "Argument `state` in call to `expr_ui()` is expected to be a named",
+        "list with unique names."
+      ),
+      class = "unsuitable_expr_ui_state"
+    )
+  }
+
+  ui_fun <- block_expr_ui(x)
+
+  if (length(state)) {
+    environment(ui_fun) <- list2env(state, parent = environment(ui_fun))
+  }
+
+  do.call(ui_fun, list(id = NS(id, "expr")))
 }
 
 #' @param result Block result

--- a/man/block_ui.Rd
+++ b/man/block_ui.Rd
@@ -9,7 +9,7 @@
 \usage{
 block_ui(id, x, ...)
 
-expr_ui(id, x, ...)
+expr_ui(id, x, state = list(), ...)
 
 block_output(x, result, session)
 
@@ -21,6 +21,9 @@ block_output(x, result, session)
 \item{x}{Object for which to generate a UI container}
 
 \item{...}{Generic consistency}
+
+\item{state}{Optional block state, which will be added to the environment
+where the block \code{expr} UI is created}
 
 \item{result}{Block result}
 

--- a/tests/testthat/test-block-ui.R
+++ b/tests/testthat/test-block-ui.R
@@ -34,3 +34,26 @@ test_that("dummy block ui test", {
     class = "superfluous_expr_ui_args"
   )
 })
+
+test_that("block ui with state", {
+
+  has_option <- function(html) {
+    grepl(
+      "option",
+      chr_ply(
+        htmltools::tagQuery(html)$find("select")$selectedTags(),
+        as.character
+      )
+    )
+  }
+
+  blk <- new_scatter_block()
+
+  ui_no_state <- expr_ui("block", blk)
+
+  expect_false(any(has_option(ui_no_state)))
+
+  ui_with_state <- expr_ui("block", blk, list(x = "a", y = "b"))
+
+  expect_true(all(has_option(ui_with_state)))
+})


### PR DESCRIPTION
@DivadNojnarg let me know what you think.

Side remark 1: Reactive in the state extracted from `rv$blocks$server$state` have to be "evaluated" before being passed to `expr_ui()`. Something like what I do in

https://github.com/BristolMyersSquibb/blockr.core/blob/918bff7111e3bd4f33d3a9d932c4492e9b22af4c/R/plugin-serialize.R#L93-L97

Side remark 2: All of this falls apart if you have UI in your block that is not part of the block "state". If this exists, it will be drawn with default values instead of "remembering". And this will happen, for example if your select options are something like `colnames()` of your input and not exposed via ctor.

I am not sure we can solve this issue with such an approach. Let's say you have a `selectInput()` and `choices` are some computed thing, such as `colnames()` of your input data. The current `choices` are lost on `removeUI()` and can only be recovered by running the `colnames()` calculation again. Does that make sense?